### PR TITLE
add: .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,9 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# local env files
+# env files
 .env*.local
+.env
 
 # vercel
 .vercel


### PR DESCRIPTION
README instructs creating a .env file but fails to protect it with .gitignore, making the instructions insecure.